### PR TITLE
examples: switch to SDL2

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,39 +6,37 @@ include_directories(
   )
 
 add_subdirectory(glu)
-
 add_subdirectory(fontstash)
-
 
 add_executable(osdemo osdemo.c)
 target_link_libraries(osdemo osmesa glu ${M_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
 set_property(TARGET osdemo APPEND PROPERTY COMPILE_DEFINITIONS "GL_DLL_IMPORTS")
 
-find_package(SDL)
+find_package(SDL2)
 
-if (SDL_FOUND)
+if (SDL2_FOUND)
   add_executable(texobj texobj.c)
-  target_link_libraries(texobj osmesa ${SDL_LIBRARY} ${M_LIBRARY})
+  target_link_libraries(texobj osmesa ${SDL2_LIBRARIES} ${M_LIBRARY})
   set_property(TARGET texobj APPEND PROPERTY COMPILE_DEFINITIONS "GL_DLL_IMPORTS")
   if (O3_COMPILER_FLAG)
     # If we have the O3 flag, use it
     target_compile_options(texobj PRIVATE "-O3")
   endif (O3_COMPILER_FLAG)
   add_executable(gears gears.c)
-  target_link_libraries(gears osmesa ${SDL_LIBRARY} ${M_LIBRARY})
+  target_link_libraries(gears osmesa ${SDL2_LIBRARIES} ${M_LIBRARY})
   set_property(TARGET gears APPEND PROPERTY COMPILE_DEFINITIONS "GL_DLL_IMPORTS")
   if (O3_COMPILER_FLAG)
     # If we have the O3 flag, use it
     target_compile_options(gears PRIVATE "-O3")
   endif (O3_COMPILER_FLAG)
   add_executable(triangle triangle.c)
-  target_link_libraries(triangle osmesa glu ${SDL_LIBRARY} ${M_LIBRARY})
+  target_link_libraries(triangle osmesa glu ${SDL2_LIBRARIES} ${M_LIBRARY})
   set_property(TARGET triangle APPEND PROPERTY COMPILE_DEFINITIONS "GL_DLL_IMPORTS")
   if (O3_COMPILER_FLAG)
     # If we have the O3 flag, use it
     target_compile_options(triangle PRIVATE "-O3")
   endif (O3_COMPILER_FLAG)
-endif (SDL_FOUND)
+endif (SDL2_FOUND)
 
 find_package(TCL)
 if (TCL_FOUND)

--- a/examples/gears.c
+++ b/examples/gears.c
@@ -12,7 +12,7 @@
 #include "OSMesa/gl.h"
 #include "OSMesa/glu.h"
 #include "OSMesa/osmesa.h"
-#include <SDL/SDL.h>
+#include <SDL2/SDL.h>
 
 #ifndef M_PI
 #  define M_PI 3.14159265
@@ -191,6 +191,7 @@ void draw()
 int main(int argc, char **argv)
 {
     SDL_Surface* screen;
+    SDL_Window* window;
     unsigned int pitch;
     int	mode;
     int winSizeX = 640;
@@ -203,22 +204,30 @@ int main(int argc, char **argv)
     unsigned int tLastFps;
     int isRunning;
     SDL_Event evt;
-    char* sdl_error;
-    const SDL_VideoInfo* info;
+    const char* sdl_error;
 
     // initialize SDL video:
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
 	fprintf(stderr,"ERROR: cannot initialize SDL video.\n");
 	return 1;
     }
-    screen = NULL;
-    info = SDL_GetVideoInfo();
-    if ((screen=SDL_SetVideoMode(winSizeX, winSizeY, info->vfmt->BitsPerPixel, SDL_SWSURFACE)) == 0) {
-	fprintf(stderr,"ERROR: Video mode set failed.\n");
-	return 1;
+
+    window = SDL_CreateWindow("", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+			      winSizeX, winSizeY, SDL_WINDOW_SHOWN);
+    if (!window) {
+	fprintf(stderr, "ERROR: Window creation failed. SDL_Error: %s\n",
+		SDL_GetError());
+	exit(1);
     }
+
+    screen = SDL_GetWindowSurface(window);
+    if (!screen) {
+	fprintf(stderr, "ERROR: Getting window surface failed. SDL_Error: %s\n",
+		SDL_GetError());
+	exit(1);
+    }
+
     //SDL_ShowCursor(SDL_DISABLE);
-    SDL_WM_SetCaption(glGetString(GL_RENDERER),0);
 
     ctx = OSMesaCreateContextExt( OSMESA_RGBA, 16, 0, 0, NULL );
     if (!ctx) {
@@ -249,6 +258,8 @@ int main(int argc, char **argv)
     frames = 0;
     tNow = SDL_GetTicks();
     tLastFps = tNow;
+
+    SDL_SetWindowTitle(window, glGetString(GL_RENDERER));
 
     // main loop:
     isRunning = 1;
@@ -321,7 +332,7 @@ int main(int argc, char **argv)
 	if (SDL_MUSTLOCK(screen)) {
 	    SDL_UnlockSurface(screen);
 	}
-	SDL_Flip(screen);
+	SDL_UpdateWindowSurface(window);
 
 	// check for error conditions:
 	sdl_error = SDL_GetError();

--- a/examples/texobj.c
+++ b/examples/texobj.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include "OSMesa/gl.h"
 #include "OSMesa/osmesa.h"
-#include <SDL/SDL.h>
+#include <SDL2/SDL.h>
 
 static GLuint TexObj[2];
 static GLfloat Angle = 0.0f;
@@ -159,6 +159,7 @@ int main(int argc, char **argv)
     // initialize SDL video:
     int winSizeX = 640;
     int winSizeY = 480;
+    SDL_Window* window;
     SDL_Surface* screen;
     unsigned int pitch;
     int	mode;
@@ -170,17 +171,25 @@ int main(int argc, char **argv)
     OSMesaContext ctx;
     void *frameBuffer;
     SDL_Event evt;
-    const SDL_VideoInfo* info;
 
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
 	fprintf(stderr,"ERROR: cannot initialize SDL video.\n");
 	return 1;
     }
-    info = SDL_GetVideoInfo();
-    screen = NULL;
-    if ((screen=SDL_SetVideoMode(winSizeX, winSizeY, info->vfmt->BitsPerPixel, SDL_SWSURFACE)) == 0) {
-	fprintf(stderr,"ERROR: Video mode set failed.\n");
-	return 1;
+
+    window = SDL_CreateWindow("", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+			      winSizeX, winSizeY, SDL_WINDOW_SHOWN);
+    if (!window) {
+	fprintf(stderr, "ERROR: Window creation failed. SDL_Error: %s\n",
+		SDL_GetError());
+	exit(1);
+    }
+
+    screen = SDL_GetWindowSurface(window);
+    if (!screen) {
+	fprintf(stderr, "ERROR: Getting window surface failed. SDL_Error: %s\n",
+		SDL_GetError());
+	exit(1);
     }
 
     ctx = OSMesaCreateContextExt( OSMESA_RGBA, 16, 0, 0, NULL );
@@ -208,7 +217,7 @@ int main(int argc, char **argv)
 	if ((t-t0) > 1.0 || frames == 0) {
 	    fps = (double)frames / (t-t0);
 	    sprintf(titlestr, "Texture Mapping (%.1f FPS)", fps);
-	    SDL_WM_SetCaption(titlestr,0);
+	    SDL_SetWindowTitle(window, titlestr);
 	    t0 = t;
 	    frames = 0;
 	}
@@ -246,7 +255,7 @@ int main(int argc, char **argv)
 	if (SDL_MUSTLOCK(screen)) {
 	    SDL_UnlockSurface(screen);
 	}
-	SDL_Flip(screen);
+	SDL_UpdateWindowSurface(window);
 
 	// check if the ESC key was pressed or the window was closed:
 

--- a/examples/triangle.c
+++ b/examples/triangle.c
@@ -8,7 +8,7 @@
 #include "OSMesa/gl.h"
 #include "OSMesa/glu.h"
 #include "OSMesa/osmesa.h"
-#include <SDL/SDL.h>
+#include <SDL2/SDL.h>
 #include "svpng.h"
 
 int main(int argc, char **argv)
@@ -16,6 +16,7 @@ int main(int argc, char **argv)
     // initialize SDL video:
     int winSizeX = 640;
     int winSizeY = 480;
+    SDL_Window* window;
     SDL_Surface* screen;
     unsigned int pitch;
     int	mode;
@@ -27,19 +28,25 @@ int main(int argc, char **argv)
     OSMesaContext ctx;
     void *frameBuffer;
     SDL_Event evt;
-    const SDL_VideoInfo* info;
 
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
 	fprintf(stderr,"ERROR: cannot initialize SDL video.\n");
 	return 1;
     }
 
-    info = SDL_GetVideoInfo();
+    window = SDL_CreateWindow("", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+			      winSizeX, winSizeY, SDL_WINDOW_SHOWN);
+    if (!window) {
+	fprintf(stderr, "ERROR: Window creation failed. SDL_Error: %s\n",
+		SDL_GetError());
+	exit(1);
+    }
 
-    screen = NULL;
-    if ((screen=SDL_SetVideoMode(winSizeX, winSizeY, info->vfmt->BitsPerPixel, SDL_SWSURFACE)) == 0) {
-	fprintf(stderr,"ERROR: Video mode set failed.\n");
-	return 1;
+    screen = SDL_GetWindowSurface(window);
+    if (!screen) {
+	fprintf(stderr, "ERROR: Getting window surface failed. SDL_Error: %s\n",
+		SDL_GetError());
+	exit(1);
     }
 
     ctx = OSMesaCreateContextExt( OSMESA_RGBA, 16, 0, 0, NULL );
@@ -69,7 +76,7 @@ int main(int argc, char **argv)
 	if ((t-t0) > 1.0 || frames == 0) {
 	    fps = (double)frames / (t-t0);
 	    sprintf(titlestr, "Spinning Triangle (%.1f FPS)", fps);
-	    SDL_WM_SetCaption(titlestr,0);
+	    SDL_SetWindowTitle(window, titlestr);
 	    t0 = t;
 	    frames = 0;
 	}
@@ -131,7 +138,7 @@ int main(int argc, char **argv)
 	if (SDL_MUSTLOCK(screen)) {
 	    SDL_UnlockSurface(screen);
 	}
-	SDL_Flip(screen);
+	SDL_UpdateWindowSurface(window);
 
 	// check if the ESC key was pressed or the window was closed:
 


### PR DESCRIPTION
One of my targets does not support SDL1, so I ported the examples to SDL2 instead.
Tested on Ubuntu 24.04 and an experimental PS5 homebrew SDK.